### PR TITLE
Fixed Contribution linking to Translations Page

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@
 
 Experience tranquility while browsing the internet with Zen! Our mission is to give you a perfect balance for speed, privacy and productivity
 
-<a href="https://docs.zen-browser.app/contribute/translation">Contribute</a> ·
+<a href="https://docs.zen-browser.app/contribute">Contribute</a> ·
 <a href="https://www.zen-browser.app">Website</a> ·
 <a href="https://docs.zen-browser.app">Docs</a> ·
 <a href="https://www.zen-browser.app/download">Download</a> ·


### PR DESCRIPTION
The Contribution was linking to the [Translations Page](https://docs.zen-browser.app/contribute/translation) not the [Contribution Guides Overview Page](https://docs.zen-browser.app/contribute/).