### PR TITLE
Fix GitHub Profile Contribute link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@
 
 Experience tranquility while browsing the internet with Zen! Our mission is to give you a perfect balance for speed, privacy and productivity
 
-<a href="https://docs.zen-browser.app/contribute/translation">Contribute</a> ·
+<a href="https://docs.zen-browser.app/contribute/CONTRIBUTING">Contribute</a> ·
 <a href="https://www.zen-browser.app">Website</a> ·
 <a href="https://docs.zen-browser.app">Docs</a> ·
 <a href="https://www.zen-browser.app/download">Download</a> ·


### PR DESCRIPTION
Quick fix to point the GitHub Profile **Contribute** link to _Contributing to Zen Browser_ docs page instead of _Getting Started with Translations_ docs page, although I also see a few other pending PRs wishing to do about the same so will let one of those get accepted when the team gets a chance to take a look.

Cheers!